### PR TITLE
Better syntax highlighting

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,8 +1,10 @@
 /dist
+/public
 /src-bex/www
 /src-capacitor
 /src-cordova
 /.quasar
+/.vscode
 /node_modules
 .eslintrc.js
 babel.config.js

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@capacitor/status-bar": "^1.0.8",
     "@octokit/core": "^3.6.0",
     "@quasar/extras": "^1.14.0",
-    "core-js": "^3.23.0",
+    "core-js": "^3.23.1",
     "electron": "19.0.4",
     "highlight.js": "^11.5.1",
     "prismjs": "^1.28.0",
@@ -54,7 +54,7 @@
     "eslint": "^8.17.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.26.0",
-    "eslint-plugin-vue": "^8.7.1",
+    "eslint-plugin-vue": "^9.1.1",
     "eslint-webpack-plugin": "^3.1.1"
   },
   "browserslist": [

--- a/public/gallery/Smartdown.md
+++ b/public/gallery/Smartdown.md
@@ -6,16 +6,52 @@ This meaningless note is designed to exercise the syntax-highlighting and editin
 
 Verify that inline code is highlighted and code fonts are monospaced. This also verifies the language auto-detection.
 
-- This is `a + b * c + 'WWWWW'`
-- This is `a + b * c + 'iiiii'`
+- Inline: `a + (b * c) + Math.sqrt('xyz') + 1000 + 'WWWWW' // This is a comment 0000`
+- Inline: `a + (b * c) + Math.sqrt('xyz') + 1000 + 'iiiii' // This is a comment 0000`
+- Inline: `set -x foo`
 
-
-#### Code Blocks
+```
+# This is a bash script
+set -x foo
+unset zzz
+echo "Hello World"
+```
 
 ```javascript
-var s = 'JavaScript syntax highlighting';
-alert(s + "foo");
-const a = 'hello' + "world!"; // comment
+var i = 1000.001 * 2 ^ 8;
+var s = 'JavaScript syntax highlighting' + Math.sqrt(i);
+const a = 'hello' + "world!" + s; // comment
+print("foo");
+```
+
+```python
+# Function for nth Fibonacci number
+def Fibonacci(n):
+
+	# Check if input is 0 then it will
+	# print incorrect input
+	if n < 0:
+		print("Incorrect input")
+
+	# Check if n is 0
+	# then it will return 0
+	elif n == 0:
+		return 0
+
+	# Check if n is 1,2
+	# it will return 1
+	elif n == 1 or n == 2:
+		return 1
+
+	else:
+		return Fibonacci(n-1) + Fibonacci(n-2)
+
+# Driver Program
+print(Fibonacci(9))
+
+# This code is contributed by Saket Modi
+# then corrected and improved by Himanshu Kanojiya
+
 ```
 
 #### Playables

--- a/src/components/Container.vue
+++ b/src/components/Container.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="q-mr-auto q-ml-auto" style="max-width: 700px;">
+  <div class="q-mr-auto q-ml-auto">
     <slot></slot>
   </div>
 </template>

--- a/src/pages/Reset.vue
+++ b/src/pages/Reset.vue
@@ -51,6 +51,7 @@ export default defineComponent({
     };
 
     const loadGallery = async () => {
+      // await deleteAllNotes(); // Useful to enable this when editing the gallery
       await loadGalleryNotes();
       router.push('/');
     };


### PR DESCRIPTION
- Update NPM dependencies
- Remove 700px width limit on Container
- Add public/ and .vscode/ to .eslintignore
- Improve Markdown syntax highlighting by highlighting inline code fragments and code blocks.
- Enhance gallery/Smartdown.md to illuminate recursive syntax highlighting
- Fix issue with non-monospace font usage in HighlightJS mode in SourceEditor.vue