### PR TITLE
0.0.5 - Autoload from Gallery via URL. Cleanup code. Better toolbar reactivity.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smartdown-quasar",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Smartdown Editor via Quasar/VueJS",
   "productName": "Smartdown Editor",
   "author": "Daniel B Keith",

--- a/publish.sh
+++ b/publish.sh
@@ -5,7 +5,7 @@
 
 REMOTE=`git remote get-url --push origin`
 rm -rf dist/spa
-SMARTDOWN_PREFIX=/smartdown-quasar GALLERY_DEV_MODE=1 npm run build
+SMARTDOWN_PREFIX=/smartdown-quasar npm run build
 mkdir /tmp/publishSQ
 cp -r dist/spa/ /tmp/publishSQ/
 cd /tmp/publishSQ/

--- a/src-capacitor/package.json
+++ b/src-capacitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smartdown-quasar",
-  "version": "0.0.3",
+  "version": "0.0.5",
   "description": "Smartdown Editor via Quasar/VueJS",
   "author": "Daniel B Keith",
   "private": true,

--- a/src/boot/smartdown.js
+++ b/src/boot/smartdown.js
@@ -6,7 +6,7 @@
 /* global smartdown */
 
 import SQ from 'src/composables/SQ';
-import { deleteAllNotes, loadGalleryNotes } from 'src/composables/notes';
+import { deleteAllNotes, loadGalleryNotes, prefetchGalleryNotes } from 'src/composables/notes';
 
 // export default async ({ app, router, store }) => {
 export default async (/* { app } */) => {
@@ -53,6 +53,13 @@ export default async (/* { app } */) => {
     },
   ];
 
+  await prefetchGalleryNotes();
+
+  if (process.env.GALLERY_DEV_MODE) {
+    deleteAllNotes();
+    loadGalleryNotes();
+  }
+
   const smartdownPrefix = process.env.SMARTDOWN_PREFIX || '';
   const baseURL = window.publicFolder || `${smartdownPrefix}/`;
   const resultPromise = new Promise((resolve) => {
@@ -60,16 +67,6 @@ export default async (/* { app } */) => {
       icons,
       baseURL,
       async () => {
-        //
-        // The following code is useful during debugging to auto-populate
-        // the notes on app restart
-        //
-
-        if (process.env.GALLERY_DEV_MODE) {
-          await deleteAllNotes();
-          await loadGalleryNotes();
-        }
-
         resolve();
       },
       cardLoader,

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -22,7 +22,7 @@ const createState = (content) => {
 
 export default {
   name: 'Editor',
-  props: ['modelValue'],
+  props: ['modelValue', 'focused'],
   data() {
     return {
       lastValue: null,
@@ -43,8 +43,14 @@ export default {
         this.$emit('update:modelValue', this.lastValue);
       },
     });
+    this.view.focus();
   },
   watch: {
+    focused(newValue) {
+      if (newValue) {
+        this.view.focus();
+      }
+    },
     modelValue(newValue) {
       if (newValue !== this.lastValue) {
         this.state = createState(newValue);

--- a/src/components/Smartdown.vue
+++ b/src/components/Smartdown.vue
@@ -30,8 +30,7 @@ export default {
   },
   setup(props) {
     const html = ref('');
-    const todo = ref(props.initInput);
-    const todoLength = ref(0);
+    const markdown = ref(props.initInput);
 
     const items = ref(['This', 'is']);
     const itemsQuantity = computed(() => items.value.length);
@@ -46,19 +45,6 @@ export default {
         currentItems.forEach((currentItem) => {
           append.value = `${currentItem} `;
         });
-      },
-      // watch Options
-      {
-        lazy: false, // immediate: true
-      },
-    );
-
-    watch(
-      // getter
-      () => todo.value.length,
-      // callback
-      (length) => {
-        todoLength.value = length;
       },
       // watch Options
       {
@@ -82,27 +68,26 @@ export default {
       const cardPath = `gallery/${SQ.cardToLoad.value}.md`;
       console.log('cardPath', cardPath);
 
-      todo.value = await (await fetch(cardPath)).text();
-      html.value = await smartdownToHTML(todo.value);
+      markdown.value = await (await fetch(cardPath)).text();
+      html.value = await smartdownToHTML(markdown.value);
       await nextTick();
       const outputDiv = document.getElementById('smartdown-output');
-      smartdown.setHome(todo.value, outputDiv, async () => {
+      smartdown.setHome(markdown.value, outputDiv, async () => {
         smartdown.startAutoplay(outputDiv);
       });
     });
 
     onMounted(async () => {
-      html.value = await smartdownToHTML(todo.value);
+      html.value = await smartdownToHTML(markdown.value);
       await nextTick();
       const outputDiv = document.getElementById('smartdown-output');
-      smartdown.setHome(todo.value, outputDiv, async () => {
+      smartdown.setHome(markdown.value, outputDiv, async () => {
         smartdown.startAutoplay(outputDiv);
       });
     });
 
     return {
-      todo,
-      todoLength,
+      markdown,
       items,
       itemsQuantity,
       append,

--- a/src/components/SourceEditor.vue
+++ b/src/components/SourceEditor.vue
@@ -4,14 +4,16 @@
     class='my-prism-editor'
     v-model='currentValue'
     :highlight='highlighter'
-    line-numbers>
+    line-numbers
+    ref="prism-editor">
   </prism-editor>
   <prism-editor
     v-else
     class='my-hljs-editor hljs'
     v-model='currentValue'
     :highlight='highlighter'
-    line-numbers>
+    line-numbers
+    ref="prism-editor">
   </prism-editor>
 </template>
 
@@ -26,7 +28,6 @@ import 'prismjs/components/prism-markup';
 import 'prismjs/components/prism-markdown';
 import 'prismjs/themes/prism-tomorrow.css';
 
-// import hljs from 'highlight.js';
 import hljs from 'highlight.js/lib/common';
 import markdown from 'highlight.js/lib/languages/markdown';
 import 'highlight.js/styles/base16/tomorrow-night.css';
@@ -35,7 +36,7 @@ hljs.registerLanguage('markdown', markdown);
 
 export default {
   name: 'SourceEditor',
-  props: ['modelValue'],
+  props: ['modelValue', 'focused'],
   data() {
     return {
       lastValue: '',
@@ -47,7 +48,17 @@ export default {
     this.lastValue = this.modelValue;
     this.currentValue = this.modelValue;
   },
+  mounted() {
+    setTimeout(() => {
+      this.$refs['prism-editor'].$refs.textarea.focus();
+    }, 1);
+  },
   watch: {
+    focused(newValue) {
+      if (newValue) {
+        this.$refs['prism-editor'].$refs.textarea.focus();
+      }
+    },
     currentValue(newValue) {
       if (newValue !== this.lastValue) {
         this.lastValue = newValue;
@@ -87,22 +98,21 @@ export default {
             }
           }
 
-          /* eslint-disable no-underscore-dangle */
-
           if (trimmedBlockLanguage) {
             trimmedBlockHtml = hljs.highlight(trimmedBlock, { language: trimmedBlockLanguage });
           } else {
             trimmedBlockHtml = hljs.highlightAuto(trimmedBlock);
           }
+          /* eslint-disable-next-line no-underscore-dangle */
           const debugBlockPrefix = useDebugPrefixes ? `(?${trimmedBlockHtml._top.name})` : '';
 
           ce.innerHTML = `${debugBlockPrefix}\`\`\`${trimmedBlockHtml.value}\`\`\``;
         } else if (ceText.startsWith('`')) {
           const trimmedInline = ceText.slice(1, -1);
           const trimmedInlineHtml = hljs.highlightAuto(trimmedInline);
+          /* eslint-disable-next-line no-underscore-dangle */
           const debugInlinePrefix = useDebugPrefixes ? `(?${trimmedInlineHtml._top.name})` : '';
 
-          // console.log('trimmedInlineHtml', trimmedInlineHtml);
           ce.innerHTML = `${debugInlinePrefix}\`${trimmedInlineHtml.value}\``;
         } else {
           console.log('other', ceText);

--- a/src/composables/store.js
+++ b/src/composables/store.js
@@ -10,67 +10,43 @@ import {
 export const initStore = () => {
   // State
   const state = reactive({
-    name: 'Bob Day',
-    email: 'bob@martianmovers.com',
-    note: null,
     editMode: {
       editing: false,
       detailed: false,
       source: false,
     },
+    note: null,
   });
 
   // Getters
-  const getUsername = computed(() => state.name);
-  const getEmail = computed(() => state.email);
-  const getNote = computed(() => state.note);
   const getEditMode = computed(() => state.editMode);
+  const getNote = computed(() => state.note);
 
   // Mutations
-  const setUsername = (name) => {
-    state.name = name;
-  };
-  const setEmail = (email) => {
-    state.email = email;
+  const setEditMode = (editMode) => {
+    state.editMode = editMode;
   };
   const setNote = (note) => {
     state.note = note;
   };
-  const setEditMode = (editMode) => {
-    state.editMode = editMode;
-  };
 
   // Actions
-  const updateUsername = (name) => {
-    setUsername(name);
-  };
-  const updateEmail = (email) => {
-    setEmail(email);
+  const updateEditMode = (editMode) => {
+    setEditMode(editMode);
   };
   const updateNote = (note) => {
     setNote(note);
   };
-  const updateEditMode = (editMode) => {
-    setEditMode(editMode);
-  };
 
-  provide('getUsername', getUsername);
-  provide('getEmail', getEmail);
   provide('getEditMode', getEditMode);
-  provide('getNote', getNote);
-  provide('updateUsername', updateUsername);
-  provide('updateEmail', updateEmail);
-  provide('updateNote', updateNote);
   provide('updateEditMode', updateEditMode);
+  provide('getNote', getNote);
+  provide('updateNote', updateNote);
 };
 
 export const useStore = () => ({
-  getUsername: inject('getUsername'),
-  getEmail: inject('getEmail'),
-  getNote: inject('getNote'),
   getEditMode: inject('getEditMode'),
-  updateUsername: inject('updateUsername'),
-  updateEmail: inject('updateEmail'),
-  updateNote: inject('updateNote'),
   updateEditMode: inject('updateEditMode'),
+  getNote: inject('getNote'),
+  updateNote: inject('updateNote'),
 });

--- a/src/pages/Export.vue
+++ b/src/pages/Export.vue
@@ -36,24 +36,27 @@ import {
   defineComponent,
   computed,
 } from 'vue';
-import { useRoute } from 'vue-router';
+import { useStore } from 'src/composables/store';
 import { exportFile, Platform } from 'quasar';
 
 // https://capacitorjs.com/docs/apis/filesystem
 import { Filesystem, Directory, Encoding } from '@capacitor/filesystem';
 
 import Container from 'src/components/Container.vue';
-import { lookupNoteByTitle } from 'src/composables/notes';
 
 export default defineComponent({
   components: { Container },
   name: 'Export',
   setup() {
-    const route = useRoute();
-    const note = computed(() => lookupNoteByTitle(route.params.id));
+    const store = useStore();
+    const note = computed({
+      get: () => store.getNote.value,
+    });
 
     const exportCurrentNote = async () => {
-      const title = note.value.title.replaceAll('/', '__');
+      const title = note.value.title
+        .replaceAll('/', '__')
+        .replaceAll(':', '..');
       const extension = title.endsWith('.md') ? '' : '.md';
       const outputFilename = `${title}${extension}`;
       const outputText = note.value.content;

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -17,23 +17,16 @@
 import Container from 'src/components/Container.vue';
 import NoteCard from 'src/components/NoteCard.vue';
 import { useLocalNotes } from 'src/composables/notes';
-import { defineComponent, reactive } from 'vue';
+import { defineComponent } from 'vue';
 import { useRouter } from 'vue-router';
 
 export default defineComponent({
   components: { NoteCard, Container },
   name: 'PageIndex',
   setup() {
-    const note = reactive({
-      title: '',
-      description: '',
-      content: '',
-    });
-
     const notes = useLocalNotes();
     const router = useRouter();
     return {
-      note,
       router,
       notes,
     };

--- a/src/pages/Reset.vue
+++ b/src/pages/Reset.vue
@@ -45,14 +45,13 @@ export default defineComponent({
       router.push('/');
     };
 
-    const clearNotes = async () => {
-      await deleteAllNotes();
+    const clearNotes = () => {
+      deleteAllNotes();
       router.push('/');
     };
 
-    const loadGallery = async () => {
-      // await deleteAllNotes(); // Useful to enable this when editing the gallery
-      await loadGalleryNotes();
+    const loadGallery = () => {
+      loadGalleryNotes();
       router.push('/');
     };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1351,10 +1351,10 @@
     "@octokit/types" "^6.0.3"
     universal-user-agent "^6.0.0"
 
-"@octokit/openapi-types@^12.6.1":
-  version "12.6.1"
-  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-12.6.1.tgz#ce33e7a75eb0e5def4e1e17547c2aeca473fed4c"
-  integrity sha512-zirGmxkSQuZIQYsOLtCxNoKi7ByKLwGhrGhHz6YUI7h/c8xOES9bEoHOeq4z81uNf2AGAqNfPW9i3GOrpgKoJQ==
+"@octokit/openapi-types@^12.7.0":
+  version "12.7.0"
+  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-12.7.0.tgz#b8e9434b5e005d88ebc49e102b39ba10d022923f"
+  integrity sha512-vWXEPETgvltt9jEYdNtQTM8xnsQ7loEbBaLV26V7Tx8ovoN8P7R3XvhFeWiboqNhlXuBsIg1QI979WElB5mGXw==
 
 "@octokit/request-error@^2.0.5", "@octokit/request-error@^2.1.0":
   version "2.1.0"
@@ -1378,11 +1378,11 @@
     universal-user-agent "^6.0.0"
 
 "@octokit/types@^6.0.3", "@octokit/types@^6.16.1":
-  version "6.38.2"
-  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.38.2.tgz#b837c76a517ebd94bb91e867eb6761ec43f3adc7"
-  integrity sha512-McFegRKQ1qaMSnDt8ScJzv26IFR1zhXveYaqx8wF7QEgiy4GHMrnX4xbP+Yl+kAr12DCplL3WJq4xkeD1VMfmw==
+  version "6.39.0"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.39.0.tgz#46ce28ca59a3d4bac0e487015949008302e78eee"
+  integrity sha512-Mq4N9sOAYCitTsBtDdRVrBE80lIrMBhL9Jbrw0d+j96BAzlq4V+GLHFJbHokEsVvO/9tQupQdoFdgVYhD2C8UQ==
   dependencies:
-    "@octokit/openapi-types" "^12.6.1"
+    "@octokit/openapi-types" "^12.7.0"
 
 "@polka/url@^1.0.0-next.20":
   version "1.0.0-next.21"
@@ -3311,9 +3311,9 @@ electron-packager@^15.5.1:
     yargs-parser "^20.0.0"
 
 electron-to-chromium@^1.4.172:
-  version "1.4.177"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.177.tgz#b6a4436eb788ca732556cd69f384b8a3c82118c5"
-  integrity sha512-FYPir3NSBEGexSZUEeht81oVhHfLFl6mhUKSkjHN/iB/TwEIt/WHQrqVGfTLN5gQxwJCQkIJBe05eOXjI7omgg==
+  version "1.4.179"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.179.tgz#450561ade3ca3497dfed65af412c672972b2dad5"
+  integrity sha512-1XeTb/U/8Xgh2YgPOqhakLYsvCcU4U7jUjTMbEnhIJoIWd/Qt3yC8y0cbG+fHzn4zUNF99Ey1xiPf20bwgLO3Q==
 
 electron@19.0.7:
   version "19.0.7"
@@ -4228,9 +4228,9 @@ globals@^11.1.0:
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
 globals@^13.15.0:
-  version "13.15.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-13.15.0.tgz#38113218c907d2f7e98658af246cef8b77e90bac"
-  integrity sha512-bpzcOlgDhMG070Av0Vy5Owklpv1I6+j96GhUI7Rh7IzDCKLzboflLrrfqMu8NquDbiR4EOQk7XzJwqVJxicxog==
+  version "13.16.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-13.16.0.tgz#9be4aca28f311aaeb974ea54978ebbb5e35ce46a"
+  integrity sha512-A1lrQfpNF+McdPOnnFqY3kSN0AFTy485bTi1bkLk4mVPODIUEcSfhHgRqA+QdXPksrSTTztYXx37NFV+GpGk3Q==
   dependencies:
     type-fest "^0.20.2"
 
@@ -6281,9 +6281,9 @@ prosemirror-keymap@^1.0.0:
     w3c-keyname "^2.2.0"
 
 prosemirror-markdown@^1.9.2:
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/prosemirror-markdown/-/prosemirror-markdown-1.9.2.tgz#bdae69db0da4319cd708bbe85beded3adbfd3cac"
-  integrity sha512-F/phUu9CgoNOySo7wtOjyq8iHyc4SvqxJVbfqO+KF9wm1xe65UeHTO/tULLKcFd8MPwFJgnPWzEF6PzAlbiKZQ==
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/prosemirror-markdown/-/prosemirror-markdown-1.9.3.tgz#13615fdeea71b744cc7bbbc64480968c8b7a2cee"
+  integrity sha512-tPJ3jEUTF3C5m60m/Eq8Y3SW6d5av0Ll61HuK1NuDP+jXsFFywG2nw500+nn7GQi5lSXP3n1HQP9zd0fpmAlzw==
   dependencies:
     markdown-it "^13.0.1"
     prosemirror-model "^1.0.0"
@@ -7655,9 +7655,9 @@ vue-prism-editor@^2.0.0-alpha.2:
   integrity sha512-Gu42ba9nosrE+gJpnAEuEkDMqG9zSUysIR8SdXUw8MQKDjBnnNR9lHC18uOr/ICz7yrA/5c7jHJr9lpElODC7w==
 
 vue-router@4:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-4.1.0.tgz#3029bf815885954ec02330e5f6fa8a00a7e5f53c"
-  integrity sha512-A+dYO0ZXLJFZ40ebW3XtqehCW0Wv2xNH4lFddOByDja4NtItEdyirrShTlvD3UA4xc5a5mG2RRI30BusYpOb9g==
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-4.1.1.tgz#90cc533efafdcf90d157bdc20a376760cdb59c10"
+  integrity sha512-Wp1mEf2xCwT0ez7o9JvgpfBp9JGnVb+dPERzXDbugTatzJAJ60VWOhJKifQty85k+jOreoFHER4r5fu062PhPw==
   dependencies:
     "@vue/devtools-api" "^6.1.4"
 


### PR DESCRIPTION
- Update NPM dependencies
- Update package.json to 0.0.5
- Refactor and simplify composables/notes.js so that the Gallery loading occurs only once and so that there is only a single reactive data structure.
- New feature: If a '/note/' URL is detected, and the URL's 'title' path parameter is not found as a Note in local storage, then the Gallery is searched, and if a matching Gallery entry is discovered, then a new Note is created based on the Gallery entry. This enables the sharing of links to a user who might not have installed the Gallery. Basically, it autoinstalls a Gallery Note if it doesn't already exist. This feature will likely be extended in the future.
- Refactor and simplify layouts/MainLayout.vue and pages/Note.vue so that MainLayout is responsible for loading a Note and putting a reactive reference into the store in composables/store.js.
- Cleanup components/Smartdown.vue to remove vestiges of the original 'ToDo List' code that inspired this app.
- Add error-handling code to MainLayout.vue so that an appropriate error message is displayed in the case of an unknown Note title.
- Improve the way that MainLayout.vue handles the toolbar functions. Ensure that 'fade mode' is disabled when 'edit mode' is enabled.
- Ensure that Editor.vue and SourceEditor.vue receive focus when 'edit mode' occurs. Ensure that focus is restored after 'detail mode' is disabled.
- Clean up composables/store.js to remove username/email, which are unused and vestiges from the origin example of how to make a store.
- Remove async/await occurrences where they were unnecessary.
- Delete dead commented code.